### PR TITLE
ci: add committer author to `semantic-release`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,4 +29,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_AUTHOR_NAME: DEVan BOTomly
+          GIT_AUTHOR_EMAIL: dev.bot@parcellab.com
+          GIT_COMMITTER_NAME: DEVan BOTomly
+          GIT_COMMITTER_EMAIL: dev.bot@parcellab.com
         run: npx semantic-release


### PR DESCRIPTION
It is an attempt to [fix the error](https://github.com/parcelLab/parcellab-utilities/actions/runs/11010199752/job/30571571308):
```
remote: error: GH006: Protected branch update failed for refs/heads/master.
```