### PR TITLE
chore: bind graylog2 instance to log functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# parcellab-utilities 
+# parcelLab Utilities 
 npm package for shared functionality
 
-**install:** `npm i --save parcellab/parcellab-utilities`
+**install:** `npm install @parcellab/utilities`
 
 ## logger
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -17,7 +17,7 @@ var _require = require('lodash'),
   isNull = _require.isNull,
   isObject = _require.isObject;
 var graylog2 = require('graylog2');
-var Graylog = graylog2.graylog;
+var Graylog2 = graylog2.graylog;
 var logger = exports.Logger = {
   settings: {
     level: process.env.LOG_LEVEL || 'DEBUG',
@@ -115,7 +115,7 @@ var colors = {
   BgCyan: '\x1b[46m',
   BgWhite: '\x1b[47m'
 };
-var colorconf = {
+var colorConf = {
   'timestamp': colors.Dim + colors.FgBlack + colors.BgWhite,
   'level': {
     'TRACE': colors.Dim + colors.BgMagenta + colors.FgBlack,
@@ -144,8 +144,15 @@ function objToString(obj) {
 }
 function colorize(part, str) {
   if (!logger.settings.color) return str;
-  if (part === 'level') return colorconf.level[str] + ' ' + str + ' ' + colors.Reset;
-  return colorconf[part] + str + colors.Reset;
+  if (part === 'level') return "".concat(colorConf.level[str], " ").concat(str, " ").concat(colors.Reset);
+  return colorConf[part] + str + colors.Reset;
+}
+function stringify(value) {
+  try {
+    return JSON.stringify(value);
+  } catch (e) {
+    return String(value);
+  }
 }
 
 // initialize the remote logger
@@ -159,7 +166,7 @@ logger.initGraylog = function () {
     hostname: os.hostname()
   };
   options.servers.push(server1);
-  var graylogger = new Graylog(options);
+  var graylogger = new Graylog2(options);
 
   /* istanbul ignore next */
   graylogger.on('error', function (error) {
@@ -178,7 +185,7 @@ function checkType(type) {
 function logThis(type) {
   return logLevels.indexOf(logger.settings.level.toUpperCase()) >= logLevels.indexOf(type);
 }
-function logLocal(type, sender, msgShort, msgLong, extras) {
+function logLocal(type, sender, msgShort, extras) {
   type = type.toUpperCase();
   var msg = (logger.settings.color ? colors.Reset : '') + (logger.settings.timestampLocal ? colorize('timestamp', new Date().toJSON()) : '') + colorize('level', type) + '<' + colorize('sender', sender) + '>: ';
   console.log(msg + msgShort);
@@ -226,15 +233,16 @@ function logToConsole(type, sender, msgShort, _extras) {
     var msgLongGray = typeof msgLong === 'string' ? msgLong.substring(0, 10000) : null;
     try {
       var leveledLogFunction = logger.graylogger[type.toLowerCase()] || logger.graylogger.info;
-      leveledLogFunction(msgShort, msgLongGray, smallExtras);
+      var bindedLogFunction = leveledLogFunction.bind(logger.graylogger);
+      bindedLogFunction(msgShort, msgLongGray, smallExtras);
     } catch (e) {
-      logLocal('error', 'logger', "trying to log something illegal? msgShort: ".concat(msgShort, " msgLong: ").concat(msgLong, " extras: ").concat(extras, " orig msg: ").concat(e), false, {
+      logLocal('error', 'logger', "Failed to log to Graylog, falling back to local.\nmsgShort: ".concat(msgShort, " | msgLong: ").concat(msgLong, " | extras: ").concat(stringify(extras), " | orig msg: ").concat(e), {
         extras: extras,
         error: e
       });
     }
   }
   if (logger.settings.developer_mode || logger.settings.saveLocal) {
-    logLocal(type, sender, msgShort, msgLong, _extras);
+    logLocal(type, sender, msgShort, _extras);
   }
 }

--- a/src/logger.js
+++ b/src/logger.js
@@ -2,9 +2,9 @@ const os = require('os')
 const { isNull, isObject } = require('lodash')
 const graylog2 = require('graylog2')
 
-const Graylog = graylog2.graylog
-
 import { isTrue, isProductionEnv } from './util'
+
+const Graylog2 = graylog2.graylog
 
 const logger = {
   settings: {
@@ -25,7 +25,6 @@ const logger = {
 
 // order is important! (severe ==> verbose)
 const logLevels = ['CRITICAL', 'ERROR', 'WARN', 'INFO', 'DEBUG', 'TRACE']
-
 
 //to enable logger instances have a default sender - shit's mainly singletonic otherwise
 class Logger {
@@ -84,7 +83,7 @@ const colors = {
   BgWhite: '\x1b[47m',
 }
 
-const colorconf = {
+const colorConf = {
   'timestamp': colors.Dim + colors.FgBlack + colors.BgWhite,
   'level': {
     'TRACE': colors.Dim + colors.BgMagenta + colors.FgBlack,
@@ -97,6 +96,7 @@ const colorconf = {
   'sender': colors.Underscore + colors.FgCyan,
   'extra': colors.FgWhite + colors.BgBlue,
 }
+
 function objToString(obj) {
   let str
   try {
@@ -108,10 +108,19 @@ function objToString(obj) {
   }
   return str
 }
+
 function colorize(part, str) {
   if (!logger.settings.color) return str
-  if (part === 'level') return colorconf.level[str] + ' ' + str + ' ' + colors.Reset
-  return colorconf[part] + str + colors.Reset
+  if (part === 'level') return `${colorConf.level[str]} ${str} ${colors.Reset}`
+  return colorConf[part] + str + colors.Reset
+}
+
+function stringify(value) {
+  try {
+    return JSON.stringify(value)
+  } catch (e) {
+    return String(value)
+  }
 }
 
 // initialize the remote logger
@@ -127,7 +136,7 @@ logger.initGraylog = function () {
   }
   options.servers.push(server1)
 
-  const graylogger = new Graylog(options)
+  const graylogger = new Graylog2(options)
 
   /* istanbul ignore next */
   graylogger.on('error', function (error) {
@@ -149,7 +158,7 @@ function logThis(type) {
   return logLevels.indexOf(logger.settings.level.toUpperCase()) >= logLevels.indexOf(type)
 }
 
-function logLocal(type, sender, msgShort, msgLong, extras) {
+function logLocal(type, sender, msgShort, extras) {
   type = type.toUpperCase()
   const msg = (logger.settings.color ? colors.Reset : '') +
     (logger.settings.timestampLocal ? colorize('timestamp', (new Date()).toJSON()) : '') +
@@ -201,20 +210,20 @@ function logToConsole(type, sender, msgShort, _extras) {
 
     try {
       const leveledLogFunction = logger.graylogger[type.toLowerCase()] || logger.graylogger.info
-      leveledLogFunction(msgShort, msgLongGray, smallExtras)
+      const bindedLogFunction = leveledLogFunction.bind(logger.graylogger)
+      bindedLogFunction(msgShort, msgLongGray, smallExtras)
     } catch (e) {
       logLocal(
         'error',
         'logger',
-        `trying to log something illegal? msgShort: ${msgShort} msgLong: ${msgLong} extras: ${extras} orig msg: ${e}`,
-        false,
+        `Failed to log to Graylog, falling back to local.\nmsgShort: ${msgShort} | msgLong: ${msgLong} | extras: ${stringify(extras)} | orig msg: ${e}`,
         { extras, error: e },
       )
     }
   }
 
   if (logger.settings.developer_mode || logger.settings.saveLocal) {
-    logLocal(type, sender, msgShort, msgLong, _extras)
+    logLocal(type, sender, msgShort, _extras)
   }
 }
 


### PR DESCRIPTION
### Description

Fixes the error:
```
TypeError: Cannot read properties of undefined (reading 'INFO')
```

This error occurred because the Graylog2 prototype variables were not [available in the context of the `.log()`](https://github.com/Wizcorp/node-graylog2/blob/master/graylog.js#L106) function.
The fix involves binding the Graylog2 instance to the log functions to ensure the correct context.